### PR TITLE
Correct parallelisation

### DIFF
--- a/mockfactory/desi/imaging_maskbits.py
+++ b/mockfactory/desi/imaging_maskbits.py
@@ -23,8 +23,6 @@ def get_maskbits(ra, dec, maskbits_fn='/global/cfs/cdirs/cosmo/data/legacysurvey
     Based on Rongpu Zhou's code:
     https://github.com/rongpu/desi-examples/blob/master/bright_star_mask/read_pixel_maskbit.py
 
-    **WANRING:** take care to split correctly ra, dec accross the rank otherwise the code is unusable
-
     Parameters
     ----------
     ra : array

--- a/mockfactory/desi/imaging_maskbits.py
+++ b/mockfactory/desi/imaging_maskbits.py
@@ -96,11 +96,13 @@ def get_maskbits(ra, dec, maskbits_fn='/global/cfs/cdirs/cosmo/data/legacysurvey
     # we do not expect that the number of particles is the same as the input on each rank
     # use out argument in mpsort.sort function
     unique_brickname, brick_counts = np.unique(np.concatenate(mpicomm.allgather(data['brickid'])), return_counts=True)
+
     # number of brick per rank
     nbr_bricks = unique_brickname.size // mpicomm.size
     if mpicomm.rank < (unique_brickname.size % mpicomm.size):
         nbr_bricks += 1
     nbr_bricks = mpicomm.allgather(nbr_bricks)
+
     # number of particles (after sort) desired per rank
     nbr_particles = np.sum(brick_counts[int(np.sum(nbr_bricks[:mpicomm.rank])): int(np.sum(nbr_bricks[:mpicomm.rank])) + nbr_bricks[mpicomm.rank]])
 
@@ -120,8 +122,8 @@ def get_maskbits(ra, dec, maskbits_fn='/global/cfs/cdirs/cosmo/data/legacysurvey
     data = np.empty(data.size, dtype=data_tmp.dtype)
     mpsort.sort(data_tmp, orderby='index', out=data)
     # test if we find the corret inital order
-#    assert np.all(data['index'] == index)
-#    maskbits = data['maskbits']
+    assert np.all(data['index'] == index)
+    maskbits = data['maskbits']
 
     return maskbits
 

--- a/mockfactory/desi/imaging_maskbits.py
+++ b/mockfactory/desi/imaging_maskbits.py
@@ -40,6 +40,8 @@ def get_maskbits(ra, dec, maskbits_fn='/global/cfs/cdirs/cosmo/data/legacysurvey
     mpicomm : MPI communicator, default=None
         The current MPI communicator.
     """
+    import mpsort
+
     def _dict_to_array(data):
         """
         Return dict as numpy array.
@@ -72,7 +74,6 @@ def get_maskbits(ra, dec, maskbits_fn='/global/cfs/cdirs/cosmo/data/legacysurvey
             maskbits = maskbits_img[coadd_y, coadd_x]
 
         else:
-            # raise ValueError
             # Sometimes we can have objects outside DR9 footprint:
             # remove these objects setting maskbits 0 (NPRIMARY pixel)
             maskbits = 2**0 * np.ones(ra.size, dtype=dtype)
@@ -80,7 +81,6 @@ def get_maskbits(ra, dec, maskbits_fn='/global/cfs/cdirs/cosmo/data/legacysurvey
         return maskbits
 
     ra, dec = np.asarray(ra), np.asarray(dec)
-    maskbits = np.ones_like(ra, dtype='i2')
 
     # load bricks class
     bricks = brick.Bricks()
@@ -88,64 +88,70 @@ def get_maskbits(ra, dec, maskbits_fn='/global/cfs/cdirs/cosmo/data/legacysurvey
     # create unique identification as index column
     cumsize = np.cumsum([0] + mpicomm.allgather(ra.size))[mpicomm.rank]
     index = cumsize + np.arange(ra.size)
-    data = _dict_to_array({'ra': ra, 'dec': dec, 'brickname': bricks.brickname(ra, dec), 'brickid': bricks.brickid(ra, dec), 'maskbits': maskbits, 'index': index})
+    data = _dict_to_array({'ra': ra, 'dec': dec, 'brickname': bricks.brickname(ra, dec), 'brickid': bricks.brickid(ra, dec), 'maskbits': np.ones_like(ra, dtype='i2'), 'index': index})
 
     # since we want to parrallelize around the brickid
-    # we do not expect that the number of particles is the same as the input on each rank
-    # use out argument in mpsort.sort function
-    unique_brickname, brick_counts = np.unique(np.concatenate(mpicomm.allgather(data['brickid'])), return_counts=True)
+    # we do not expect that the number of particles is the same as the input on each rank (use out argument in mpsort.sort function)
+    # take care: compute nbr_particles only in rank 0 to avoid troubles with large array communcation and blow up the memory of the rank (collection of large array in all the rank)
 
-    # number of brick per rank
-    nbr_bricks = unique_brickname.size // mpicomm.size
-    if mpicomm.rank < (unique_brickname.size % mpicomm.size):
-        nbr_bricks += 1
-    nbr_bricks = mpicomm.allgather(nbr_bricks)
+    # reduce the array which will be send to root rank:
+    local_unique_brickname, local_brick_counts = np.unique(data['brickid'], return_counts=True)
 
-    # number of particles (after sort) desired per rank
-    nbr_particles = np.sum(brick_counts[int(np.sum(nbr_bricks[:mpicomm.rank])): int(np.sum(nbr_bricks[:mpicomm.rank])) + nbr_bricks[mpicomm.rank]])
+    # collect the info only in the root rank:
+    local_unique_brickname, local_brick_counts = mpicomm.gather(local_unique_brickname), mpicomm.gather(local_brick_counts)
+
+    # compute the nbr particles that will contain each rank after sorting. Do it only in root rank.
+    nbr_particles = None
+    if mpicomm.rank == 0:
+        local_unique_brickname, local_brick_counts = np.concatenate(local_unique_brickname), np.concatenate(local_brick_counts)
+        unique_brickname = np.unique(local_unique_brickname)
+        brick_counts = np.array([local_brick_counts[local_unique_brickname == brickname].sum() for brickname in unique_brickname])
+
+        # number of brick per rank
+        nbr_bricks = unique_brickname.size // mpicomm.size + np.array([1 if i < (unique_brickname.size % mpicomm.size) else 0 for i in range(mpicomm.size)])
+
+        # number of particles (after sort) desired per rank
+        nbr_particles = [np.sum(brick_counts[int(np.sum(nbr_bricks[:i])): int(np.sum(nbr_bricks[:i])) + nbr_bricks[i]]) for i in range(mpicomm.size)]
+
+    # send the nbr particles that will contain each rank after sorting
+    nbr_particles = mpicomm.scatter(nbr_particles)
 
     # sort data to have same number of bricks in each available rank
-    import mpsort
     data_tmp = np.empty(nbr_particles, dtype=data.dtype)
     mpsort.sort(data, orderby='brickid', out=data_tmp)
 
-    if mpicomm.rank == 0:
-        logger.info(f'Nbr of bricks to read per rank = {np.min(nbr_bricks)}/{np.max(nbr_bricks)} (min/max)')
+    if mpicomm.rank == 0: logger.info(f'Nbr of bricks to read per rank = {np.min(nbr_bricks)}/{np.max(nbr_bricks)} (min/max)')
 
     for brickname in np.unique(data_tmp['brickname']):
         mask_brick = data_tmp['brickname'] == brickname
         region = 'north' if bricks.brick_radec(data_tmp['ra'][mask_brick][0], data_tmp['dec'][mask_brick][0])[1] > 32.375 else 'south'
         data_tmp['maskbits'][mask_brick] = get_brick_maskbits(maskbits_fn.format(region=region, brickname=brickname), data_tmp['ra'][mask_brick], data_tmp['dec'][mask_brick])
 
+    # collect the data in the intial order
     data = np.empty(data.size, dtype=data_tmp.dtype)
     mpsort.sort(data_tmp, orderby='index', out=data)
+
     # test if we find the corret inital order
     assert np.all(data['index'] == index)
-    maskbits = data['maskbits']
 
-    return maskbits
+    return data['maskbits']
 
 
 if __name__ == '__main__':
-
     from mockfactory import RandomCutskyCatalog, setup_logging
-
-    mpicomm = MPI.COMM_WORLD
 
     setup_logging()
 
-    if mpicomm.rank == 0:
-        logger.info('Run simple example to illustrate how to apply DR9 maskbits.')
+    mpicomm = MPI.COMM_WORLD
+
+    if mpicomm.rank == 0: logger.info('Run simple example to illustrate how to apply DR9 maskbits.')
 
     # Generate example cutsky catalog, scattered on all processes
     cutsky = RandomCutskyCatalog(rarange=(20., 30.), decrange=(-0.5, 2.), size=10000, seed=44, mpicomm=mpicomm)
-    start = MPI.Wtime()
-
     ra, dec = cutsky['RA'], cutsky['DEC']
-    if mpicomm.rank == 1:
-        # to test when empty catalog is given with MPI
-        ra, dec = [], []
+    # to test when empty catalog is given with MPI
+    if mpicomm.rank == 1: ra, dec = [], []
 
+    start = MPI.Wtime()
     maskbits = get_maskbits(ra, dec, mpicomm=mpicomm)
-    if mpicomm.rank == 0:
-        logger.info(f'Apply DR9 maskbits done in {MPI.Wtime() - start:2.2f} s.')
+    if mpicomm.rank == 0: logger.info(f'Apply DR9 maskbits done in {MPI.Wtime() - start:2.2f} s.')


### PR DESCRIPTION
The previous code (even if it was not well written) could correctly parallelize around the number of bricks (what we want to do since the problem is the I/O) to read what the current code does not. 

The new code as it stands does not work with:
* Void catalogue in one process 
* twice slower than the previous implementation in the current example (51 bricks to open in rank 0 against 30 in the previous implementation)
* do not well parallelize around the number of bricks since `mpsort` return the same number of particles in each rank. An example, where the parallelization does not work: 20 particles in the same bricks (rank 0) and 20 particles in different bricks (rank 1), the code will take almost the same amount of time as if it is run only in one process. 

With this update:
* works with void catalogue
* split the same number of bricks on each rank, solving the two last raised issues.
* Now, if some ranks have void catalog they are also use for the parallelisation